### PR TITLE
Fix getUserSettings() behaviour

### DIFF
--- a/msui.hsl
+++ b/msui.hsl
@@ -77,22 +77,21 @@ class msui
     $settings = [];
 
     $userData = $this->getUser($user);
-    $user = envelope_address_parse($userData["username"]);
+    $user = envelope_address_parse($userData ? $userData["username"] : $user);
 
-    if ($userData)
-    {
-      $domainData = $this->getDomain($user["domain"]);
+    $domainData = $this->getDomain($user["domain"]);
+    if ($domainData)
       $globalSettings = $this->getGlobalSettingsByDomain($domainData);
-    }
 
     foreach ($config["settings"]->entries() as $identifier => $schemaSetting)
     {
       if (!array_includes($schemaSetting["schema"]["access_type"], ["all", "user"]))
         continue;
-      if ($userData and $domainData)
+      if ($domainData)
       {
         $domainSettings = $schemaSetting["domains"]->get($domainData["domain"]);
-        $userSettings = $domainSettings["users"] ? $domainSettings["users"]->get($userData["username"]) : [];
+        if ($userData)
+          $userSettings = $domainSettings["users"] ? $domainSettings["users"]->get($userData["username"]) : [];
       }
 
       $settings[$identifier] = $this->getInheritedValue(


### PR DESCRIPTION
getUserSettings() returned schema settings for unknown users but known domains:

getUserSettings of known user returns [User]
getUserSettings of unknown user / known domain returns [Schema]
getUserSettings of unknown user / unknown domain returns [Schema]

This patch changes the code to return domain settings in that case. So with this:

getUserSettings of known user returns [User]
getUserSettings of unknown user / known domain returns [Domain]
getUserSettings of unknown user / unknown domain returns [Schema]

Setting not defined at user level
getUserSettings of known user returns [Domain]
getUserSettings of unknown user / known domain returns [Domain]
getUserSettings of unknown user / unknown domain returns [Schema]

No setting at user or domain level
getUserSettings of known user returns [Global]
getUserSettings of unknown user / known domain returns [Global]
getUserSettings of unknown user / unknown domain returns [Schema]
